### PR TITLE
Unpack parameters for \Contao\Database\Statement::execute()

### DIFF
--- a/src/Widget/TableLookupWizard.php
+++ b/src/Widget/TableLookupWizard.php
@@ -249,7 +249,7 @@ class TableLookupWizard extends Widget
             $objStatement->limit($this->intLimit + 1);
         }
 
-        $objResults = $objStatement->execute($this->arrQueryValues);
+        $objResults = $objStatement->execute(...$this->arrQueryValues);
 
         while ($objResults->next()) {
             $arrRow = $objResults->row();


### PR DESCRIPTION
Due to a change in Contao 5 (and deprecation in 4.13), Statement::execute() doesn't work with an array of parameters anymore. This unpacks the array.